### PR TITLE
 (Fix) Support added for Deno versions 1.4.X

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -1,5 +1,5 @@
-import { PromptOpts, GlobalPromptOpts } from './src/core/prompt.ts';
-import { Result } from './src/core/result.ts';
+import type { PromptOpts, GlobalPromptOpts } from './src/core/prompt.ts';
+import type { Result } from './src/core/result.ts';
 
 import Input from './src/input.ts';
 import Number, { NumberOpts } from './src/number.ts';

--- a/src/confirm.ts
+++ b/src/confirm.ts
@@ -1,6 +1,6 @@
 import Text from './core/text.ts';
-import { PromptOpts } from './core/prompt.ts';
-import { Result } from './core/result.ts';
+import type { PromptOpts } from './core/prompt.ts';
+import type { Result } from './core/result.ts';
 
 export interface ConfirmOpts extends PromptOpts {
   accept?: string;

--- a/src/input.ts
+++ b/src/input.ts
@@ -1,6 +1,6 @@
 import Text from './core/text.ts';
-import { PromptOpts } from './core/prompt.ts';
-import { Result } from './core/result.ts';
+import type { PromptOpts } from './core/prompt.ts';
+import type { Result } from './core/result.ts';
 
 class Input extends Text {
   constructor(opts: PromptOpts) {

--- a/src/number.ts
+++ b/src/number.ts
@@ -1,6 +1,6 @@
 import Text from './core/text.ts';
-import { PromptOpts } from './core/prompt.ts';
-import { Result } from './core/result.ts';
+import type { PromptOpts } from './core/prompt.ts';
+import type { Result } from './core/result.ts';
 
 export interface NumberOpts extends PromptOpts {
   min?: number;


### PR DESCRIPTION
 - Resolved warning : This import is never used as a value and must use 'import type' because the 'importsNotUsedAsValues' is set to 'error'