### PR TITLE
Fix: prompt type defaults to "input" and better typing

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -36,10 +36,6 @@ class Ask {
       cache = questions[i];
 
       switch (cache.type) {
-        case 'input':
-          Object.assign(answers, await this.input(cache));
-          break;
-
         case 'number':
           Object.assign(answers, await this.number(cache));
           break;
@@ -49,6 +45,7 @@ class Ask {
           break;
 
         default:
+          Object.assign(answers, await this.input(cache));
           break;
       }
     }

--- a/src/confirm.ts
+++ b/src/confirm.ts
@@ -3,6 +3,7 @@ import type { PromptOpts } from './core/prompt.ts';
 import type { Result } from './core/result.ts';
 
 export interface ConfirmOpts extends PromptOpts {
+  type: 'confirm';
   accept?: string;
   deny?: string;
 }

--- a/src/core/prompt.ts
+++ b/src/core/prompt.ts
@@ -1,6 +1,8 @@
+export type PromptType = 'input' | 'number' | 'confirm';
+
 export interface PromptOpts {
   name: string;
-  type?: string;
+  type?: PromptType;
   message?: string;
   prefix?: string;
   suffix?: string;
@@ -19,7 +21,7 @@ export interface GlobalPromptOpts {
 
 class Prompt {
   protected name: string;
-  protected type?: string;
+  protected type?: PromptType;
   protected message: string;
   protected prefix?: string;
   protected suffix?: string;

--- a/src/core/prompt.ts
+++ b/src/core/prompt.ts
@@ -34,7 +34,7 @@ class Prompt {
     }
 
     this.name = opts.name;
-    this.type = opts.type ?? 'text';
+    this.type = opts.type ?? 'input';
     this.message = opts.message ?? opts.name;
     this.prefix = opts.prefix ?? '\x1b[32m?\x1b[39m';  // Green "?"
     this.suffix = opts.suffix ?? (!opts.message && opts.suffix == null ? ':' : '');

--- a/src/number.ts
+++ b/src/number.ts
@@ -3,6 +3,7 @@ import type { PromptOpts } from './core/prompt.ts';
 import type { Result } from './core/result.ts';
 
 export interface NumberOpts extends PromptOpts {
+  type: 'number';
   min?: number;
   max?: number;
 }


### PR DESCRIPTION
Previously, if the prompt type is not specified, it silently fails to prompt the user. This PR fixes the issue along with better typing in general.