### PR TITLE
Checkbox defaults + Select by typing number

### DIFF
--- a/examples/lists.ts
+++ b/examples/lists.ts
@@ -1,0 +1,50 @@
+import iro, { cyan, gray } from "@sallai/iro";
+import * as Ask from "../mod.ts";
+
+const indent = " ".repeat(8);
+
+const ask = new Ask.Ask({ prefix: "\n" + " ".repeat(6), suffix: "\n" });
+
+const listFormatters = {
+  activeFormatter: (message: string): string => {
+    return iro(`${indent}● ${message}`, cyan);
+  },
+  inactiveFormatter: (message: string): string => {
+    return `${indent}  ${message}`;
+  },
+  disabledFormatter: (message: string): string => {
+    return iro(`${indent}- ${message} (disabled)`, gray);
+  },
+};
+
+const result = await ask.select(
+  {
+    name: "letter",
+    type: "select",
+    message: "Select your favorite letter",
+    useNumbers: true,
+    choices: [
+      { message: "A", value: "a" },
+      { message: "B", value: "b" },
+      { message: "C", value: "c" },
+    ],
+    ...listFormatters,
+  },
+);
+const result2 = await ask.checkbox(
+  {
+    name: "colors",
+    type: "checkbox",
+    message: "Select your favorite colors",
+    choices: [
+      { message: "Red", value: "red" },
+      { message: "Green", value: "green" },
+      { message: "Blue", value: "blue" },
+    ],
+    defaultValues: ["green", "blue"],
+    ...listFormatters,
+  },
+);
+
+console.log(result);
+console.log(result2);


### PR DESCRIPTION
Added two basic features without disrupting anything else, I hope.
The first is to have checkbox defaults, so you can round trip checkbox preferences.
The second is to be able to select a Select option by typing a number.
There is an `examples/lists.ts` file showing these changes.
Let me know if you're actively maintaining this project. If not, I may just fork and grow this for my own purposes.

Changes have only been exercised on a Mac.